### PR TITLE
refactor: avoid creating Graphics object for every frame rendered.

### DIFF
--- a/fireplace-app/src/main/java/com/github/bric3/fireplace/FlameGraphTab.java
+++ b/fireplace-app/src/main/java/com/github/bric3/fireplace/FlameGraphTab.java
@@ -75,7 +75,7 @@ public class FlameGraphTab extends JPanel {
 
         var borderToggle = new JCheckBox("Border");
         borderToggle.addActionListener(e -> {
-            jfrFlameGraph.setPaintFrameBorder(borderToggle.isSelected());
+            jfrFlameGraph.setFrameGapEnabled(borderToggle.isSelected());
             jfrFlameGraph.requestRepaint();
         });
         borderToggle.setSelected(defaultPaintFrameBorder);

--- a/fireplace-swing/src/main/java/com/github/bric3/fireplace/flamegraph/FlameGraph.java
+++ b/fireplace-swing/src/main/java/com/github/bric3/fireplace/flamegraph/FlameGraph.java
@@ -110,13 +110,13 @@ public class FlameGraph<T> {
     }
 
     /**
-     * Toggle the display of borders around frames.
+     * Toggle the display of a gap between frames.
      *
-     * @param paintFrameBorder {@code true} to paint borders around frames, {@code false} otherwise.
+     * @param frameGapEnabled {@code true} to show a gap between frames, {@code false} otherwise.
      */
-    public void setPaintFrameBorder(boolean paintFrameBorder) {
+    public void setFrameGapEnabled(boolean frameGapEnabled) {
         canvas.getFlameGraphPainter()
-              .ifPresent(fgp -> fgp.paintFrameBorder = paintFrameBorder);
+              .ifPresent(fgp -> fgp.frameGapEnabled = frameGapEnabled);
     }
 
     /**

--- a/fireplace-swing/src/main/java/com/github/bric3/fireplace/flamegraph/FlameGraphPainter.java
+++ b/fireplace-swing/src/main/java/com/github/bric3/fireplace/flamegraph/FlameGraphPainter.java
@@ -36,7 +36,7 @@ public class FlameGraphPainter<T> {
     public boolean paintHoveredFrameBorder = true;
     public int frameBorderWidth = 1;
     public Stroke frameBorderStroke = new BasicStroke(frameBorderWidth);
-    public Color frameBorderColor = Color.WHITE;
+    public Color frameBorderColor = Colors.panelForeground;
 
     private final int depth;
     private int visibleDepth;

--- a/fireplace-swing/src/main/java/com/github/bric3/fireplace/flamegraph/FlameGraphPainter.java
+++ b/fireplace-swing/src/main/java/com/github/bric3/fireplace/flamegraph/FlameGraphPainter.java
@@ -241,7 +241,7 @@ public class FlameGraphPainter<T> {
         }
 
         rect.x = (int) (flameGraphWidth * hoveredFrame.startX) + internalPadding;
-        rect.width = ((int) (flameGraphWidth * hoveredFrame.endX)) - rect.x - internalPadding - frameBorderWidth - (frameGapEnabled ? frameGapWidth : 0);
+        rect.width = ((int) (flameGraphWidth * hoveredFrame.endX)) - rect.x - internalPadding - frameBorderWidth;
 
         if ((rect.width < frameWidthVisibilityThreshold)) {
             return;

--- a/fireplace-swing/src/main/java/com/github/bric3/fireplace/flamegraph/FlameGraphPainter.java
+++ b/fireplace-swing/src/main/java/com/github/bric3/fireplace/flamegraph/FlameGraphPainter.java
@@ -36,6 +36,7 @@ public class FlameGraphPainter<T> {
     public boolean paintHoveredFrameBorder = true;
     public int frameBorderWidth = 1;
     public Stroke frameBorderStroke = new BasicStroke(frameBorderWidth);
+    public Color frameBorderColor = Color.WHITE;
 
     private final int depth;
     private int visibleDepth;
@@ -240,19 +241,19 @@ public class FlameGraphPainter<T> {
         }
 
         rect.x = (int) (flameGraphWidth * hoveredFrame.startX) + internalPadding;
-        rect.width = ((int) (flameGraphWidth * hoveredFrame.endX)) - rect.x - internalPadding - frameGapWidth;
+        rect.width = ((int) (flameGraphWidth * hoveredFrame.endX)) - rect.x - internalPadding - frameBorderWidth - (frameGapEnabled ? frameGapWidth : 0);
 
         if ((rect.width < frameWidthVisibilityThreshold)) {
             return;
         }
 
         rect.y = frameBoxHeight * hoveredFrame.stackDepth;
-        rect.height = frameBoxHeight;
+        rect.height = frameBoxHeight - frameGapWidth;
 
         if (visibleRect.intersects(rect)) {
-            g2.setColor(Color.WHITE);
+            g2.setColor(frameBorderColor);
             g2.setStroke(frameBorderStroke);
-            g2.drawRect(rect.x, rect.y, rect.width - frameBorderWidth, rect.height - frameGapWidth - frameBorderWidth);
+            g2.draw(rect);
         }
     }
 


### PR DESCRIPTION
The rendering performance (cpu and allocation) can be improved by avoiding the creation of a new `Graphics2D` instance for each frame that is rendered.  This requires the `(x, y)` location of the frames to be managed and in the process of doing this I renamed the `frameBorder` to `frameGap` since that appears to be a better description of what is actually drawn.  

Based on the test program below, you can see a significant memory allocation BEFORE:

![image](https://user-images.githubusercontent.com/1835893/158405356-ca03322b-442b-43be-8f41-4a06f2997b2a.png)

And this is gone AFTER:

![image](https://user-images.githubusercontent.com/1835893/158405936-fe85c4ce-a0b0-4bf7-98f5-0d81928ec233.png)

CPU-wise the test rendering averaged (for three runs) 1.303 seconds after the patch, versus 1.355 before the patch (roughly a 4% increase in speed).

```package com.github.bric3.fireplace;

import com.github.bric3.fireplace.core.ui.Colors;
import com.github.bric3.fireplace.flamegraph.ColorMapper;
import com.github.bric3.fireplace.flamegraph.FlameGraphPainter;
import com.github.bric3.fireplace.flamegraph.FrameBox;
import org.openjdk.jmc.common.item.IItemCollection;
import org.openjdk.jmc.common.item.ItemFilters;
import org.openjdk.jmc.flightrecorder.CouldNotLoadRecordingException;
import org.openjdk.jmc.flightrecorder.JfrLoaderToolkit;
import org.openjdk.jmc.flightrecorder.stacktrace.tree.Node;
import org.openjdk.jmc.flightrecorder.stacktrace.tree.StacktraceTreeModel;

import javax.imageio.ImageIO;
import java.awt.*;
import java.awt.image.BufferedImage;
import java.io.File;
import java.io.IOException;
import java.nio.file.Path;
import java.time.Duration;
import java.time.Instant;
import java.util.List;
import java.util.Set;

import static java.util.stream.Collectors.joining;

/**
 * Checks the rendering performance of the flame graph.
 */
public class FirePlacePerformanceCheck {

    private static final int WARM_UP_REPS = 1000;

    private static final int PERF_CHECK_REPS = 1000;


    public static void main(String[] args) {

        System.out.println("starting...");
        // load a JFR file and use JMC to extract a StacktraceTreeModel
        final StacktraceTreeModel stackTraceTreeModel;
        Path path = Path.of("/Users/david.gilbert/JFreeSVGTestRunner_2022_03_15_090614.jfr"); 
        try {
            IItemCollection events = JfrLoaderToolkit.loadEvents(new File("/Users/david.gilbert/JFreeSVGTestRunner_2022_03_15_090614.jfr"));
            stackTraceTreeModel = new StacktraceTreeModel(events.apply(ItemFilters.type(Set.of(
                    "jdk.ExecutionSample"
            ))));
            // create a FlameGraphPainter from the CPU profile
            List<FrameBox<Node>> frameBoxList = JfrFrameNodeConverter.convert(stackTraceTreeModel);
            var flameGraphPainter = new FlameGraphPainter<>(
                    frameBoxList,
                    List.of(
                            node -> node.getFrame().getHumanReadableShortString(),
                            node -> node.getFrame().getMethod().getMethodName()
                    ),
                    node -> {
                        var eventTypes = stackTraceTreeModel.getItems()
                                .stream()
                                .map(iItems -> iItems.getType().getIdentifier())
                                .collect(joining(", "));
                        return "all (" + eventTypes + ")";
                    },
                    JfrFrameColorMode.BY_PACKAGE.colorMapperUsing(ColorMapper.ofObjectHashUsing(Colors.Palette.DATADOG.colors()))
            );

            // render it M times to warm up
            BufferedImage image = new BufferedImage(1200, 600, BufferedImage.TYPE_INT_ARGB);
            flameGraphPainter.computeFlameGraphDimension(image.createGraphics(),
                    new Rectangle(0, 0, 1200, 600), new Insets(0, 0, 0, 0)
            );

            System.out.println("warming up...");
            for (int m = 0; m < WARM_UP_REPS; m++) {
                flameGraphPainter.paint(image.createGraphics(), new Rectangle(0, 0, 1200, 600));
            }

            // render it N times and check the time
            System.out.println("measuring");
            Instant start = Instant.now();
            for (int n = 0; n < PERF_CHECK_REPS; n++) {
                flameGraphPainter.paint(image.createGraphics(), new Rectangle(0, 0, 1200, 600));
            }
            System.out.println("Rendered " + PERF_CHECK_REPS + " times in " + Duration.between(start, Instant.now()));
            ImageIO.write(image, "png", new File("fireplace.png"));
        } catch (IOException e) {
            e.printStackTrace();
        } catch (CouldNotLoadRecordingException e) {
            e.printStackTrace();
        }

    }
}