### PR TITLE
fix: correctly dims frames adjacent to selected frame. See #28.

### DIFF
--- a/fireplace-swing/src/main/java/com/github/bric3/fireplace/flamegraph/FlameGraphPainter.java
+++ b/fireplace-swing/src/main/java/com/github/bric3/fireplace/flamegraph/FlameGraphPainter.java
@@ -206,8 +206,8 @@ public class FlameGraphPainter<T> {
                                                     false,
                                                     selectedFrame != null && (
                                                             frame.stackDepth < selectedFrame.stackDepth
-                                                            || frame.endX < selectedFrame.startX
-                                                            || frame.startX > selectedFrame.endX),
+                                                            || frame.endX <= selectedFrame.startX
+                                                            || frame.startX >= selectedFrame.endX),
                                                     minimapMode),
                                         frameBorderColor,
                                         minimapMode);


### PR DESCRIPTION
Fixes https://github.com/bric3/fireplace/issues/28

After the fix:

<img width="341" alt="image" src="https://user-images.githubusercontent.com/1835893/158417457-135737b5-1519-4f7f-b444-f01d3856c969.png">
