### PR TITLE
fix: Single-click on frame repositions flame graph unexpectedly. #31.

### DIFF
--- a/fireplace-swing/src/main/java/com/github/bric3/fireplace/flamegraph/FlameGraph.java
+++ b/fireplace-swing/src/main/java/com/github/bric3/fireplace/flamegraph/FlameGraph.java
@@ -556,12 +556,16 @@ public class FlameGraph<T> {
             var mouseAdapter = new MouseAdapter() {
                 @Override
                 public void mousePressed(MouseEvent e) {
-                    processMinimapMouseEvent(e);
+                    if (isInsideMinimap(e.getPoint())) {
+                        processMinimapMouseEvent(e);
+                    }
                 }
 
                 @Override
                 public void mouseDragged(MouseEvent e) {
-                    processMinimapMouseEvent(e);
+                    if (isInsideMinimap(e.getPoint())) {
+                        processMinimapMouseEvent(e);
+                    }
                 }
 
                 private void processMinimapMouseEvent(MouseEvent e) {


### PR DESCRIPTION
Fixes https://github.com/bric3/fireplace/issues/31