### PR TITLE
feat: add animated transition to frame on double-click.

### DIFF
--- a/fireplace-swing/build.gradle.kts
+++ b/fireplace-swing/build.gradle.kts
@@ -8,6 +8,14 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation(libs.radianceanimation)
+}
+
 tasks {
     withType(JavaCompile::class) {
         options.release.set(11)

--- a/fireplace-swing/src/main/java/io/github/bric3/fireplace/flamegraph/FlameGraph.java
+++ b/fireplace-swing/src/main/java/io/github/bric3/fireplace/flamegraph/FlameGraph.java
@@ -285,7 +285,7 @@ public class FlameGraph<T> {
                         viewPort.getViewRect(),
                         point
                 )).ifPresent(zoomTarget -> {
-                    System.getLogger(FlameGraphCanvas.class.getName()).log(System.Logger.Level.INFO,() -> "zoom to " + zoomTarget);
+                    System.getLogger(FlameGraphCanvas.class.getName()).log(System.Logger.Level.DEBUG,() -> "zoom to " + zoomTarget);
                     int startW = canvas.getWidth();
                     int startH = canvas.getHeight();
                     double deltaW = zoomTarget.bounds.width - startW;
@@ -311,9 +311,11 @@ public class FlameGraph<T> {
                                 }
                                 @Override
                                 public void onTimelinePulse(float durationFraction, float timelinePosition) {
-                                    canvas.setSize(new Dimension((int) (startW + timelinePosition * deltaW), (int) (startH + timelinePosition * deltaH)));
-                                    Point pos = new Point(startX + (int) (timelinePosition * deltaX), startY + (int) (timelinePosition * deltaY));
-                                    viewPort.setViewPosition(pos);
+                                    SwingUtilities.invokeLater(() -> {
+                                        canvas.setSize(new Dimension((int) (startW + timelinePosition * deltaW), (int) (startH + timelinePosition * deltaH)));
+                                        Point pos = new Point(startX + (int) (timelinePosition * deltaX), startY + (int) (timelinePosition * deltaY));
+                                        viewPort.setViewPosition(pos);
+                                    });
                                 }
                             }).build().playSkipping(3L);
                 });

--- a/fireplace-swing/src/main/java/io/github/bric3/fireplace/flamegraph/FlameGraphPainter.java
+++ b/fireplace-swing/src/main/java/io/github/bric3/fireplace/flamegraph/FlameGraphPainter.java
@@ -12,6 +12,7 @@ package io.github.bric3.fireplace.flamegraph;
 import io.github.bric3.fireplace.core.ui.Colors;
 
 import java.awt.*;
+import java.awt.geom.Rectangle2D;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -46,11 +47,8 @@ public class FlameGraphPainter<T> {
 
     private FrameBox<T> hoveredFrame;
     private FrameBox<T> selectedFrame;
-    private int visibleWidth;
     private double scaleX;
     private double scaleY;
-    private double zoomFactor = 1d;
-    private int flameGraphWidth;
 
     private final List<FrameBox<T>> frames;
     private final List<Function<T, String>> nodeToTextCandidates;
@@ -102,80 +100,68 @@ public class FlameGraphPainter<T> {
         return visibleDepth * minimapFrameBoxHeight;
     }
 
-    public Dimension computeFlameGraphDimension(Graphics2D g2, Rectangle visibleRect, Insets insets) {
+    /**
+     * Computes the dimensions of the flamegraph for the specified width (just the height needs calculating,
+     * and this depends on the font metrics).
+     *
+     * @param g2     the graphics target.
+     * @param width  the preferred width.
+     * @param insets the insets.
+     *
+     * @return The dimensions required to draw the whole fra
+     */
+    public Dimension computeFlameGraphDimension(Graphics2D g2, int width, Insets insets) {
         // as this method is invoked during layout, the dimension can be 0
-        if (visibleRect.width == 0) {
+        if (width == 0) {
             return new Dimension();
         }
 
-
-        var visibleWidth = visibleRect.width - insets.left - insets.right;
-
-        // compute the canvas height for the flamegraph width
-        if (this.visibleWidth != visibleWidth) {
-            var preferredFlameGraphWidth = ((int) (zoomFactor * visibleWidth)) - insets.left - insets.right;
-
-            var visibleDepth = 0;
-            for (var frame : frames) {
-                if ((int) (preferredFlameGraphWidth * (frame.endX - frame.startX)) < frameWidthVisibilityThreshold) {
-                    continue;
-                }
-
-                visibleDepth = Math.max(visibleDepth, frame.stackDepth);
-            }
-
-            this.flameGraphWidth = preferredFlameGraphWidth;
-            this.visibleWidth = visibleWidth;
-            this.visibleDepth = Math.min(visibleDepth, depth);
-//            System.out.println("getFlameGraphDimension, fgWidth=" + flameGraphWidth +
-//                               " new fgWidth=" + preferredFlameGraphWidth + " visibleWidth=" + visibleWidth + " visibleDepth=" + visibleDepth + " zoom=" + zoomFactor);
-        }
-
-//        System.out.println("getFlameGraphDimension, fgWidth=" + flameGraphWidth + " visibleWidth=" + visibleWidth + " visibleDepth=" + visibleDepth + " zoom=" + zoomFactor);
-
-        return new Dimension(flameGraphWidth, this.visibleDepth * getFrameBoxHeight(g2));
+        return new Dimension(width + insets.left + insets.right, depth * getFrameBoxHeight(g2));
     }
 
     private float getFrameBoxTextOffset(Graphics2D g2) {
         return getFrameBoxHeight(g2) - (g2.getFontMetrics().getDescent() / 2f) - textBorder - frameGapWidth;
     }
 
-    public void paint(Graphics2D g2, Rectangle visibleRect) {
-        assert flameGraphWidth > 0 : "canvas sizing not done yet";
-        paint(g2, visibleRect, false);
+    public void paint(Graphics2D g2, Rectangle2D bounds, Rectangle2D viewRect) {
+        paint(g2, bounds, viewRect, false);
     }
 
-    public void paintMinimap(Graphics2D g2, Rectangle visibleRect) {
-        assert flameGraphWidth > 0 : "canvas sizing not done yet";
-        paint(g2, visibleRect, true);
+    /**
+     * Paints the minimap (always the entire flame graph).
+     *
+     * @param g2     the graphics target.
+     * @param bounds the bounds.
+     */
+    public void paintMinimap(Graphics2D g2, Rectangle2D bounds) {
+        paint(g2, bounds, bounds, true);
     }
 
-    private void paint(Graphics2D g2, Rectangle visibleRect, boolean minimapMode) {
+    private void paint(Graphics2D g2, Rectangle2D bounds, Rectangle2D viewRect, boolean minimapMode) {
         long start = System.currentTimeMillis();
         Graphics2D g2d = (Graphics2D) g2.create();
         var frameBoxHeight = minimapMode ? minimapFrameBoxHeight : getFrameBoxHeight(g2);
-        var flameGraphWidth = minimapMode ? visibleRect.width : this.flameGraphWidth;
-        var rectOnCanvas = new Rectangle(); // reusable rectangle
+        var flameGraphWidth = minimapMode ? viewRect.getWidth() : bounds.getWidth();
+        var rect = new Rectangle(); // reusable rectangle
 
         identifyDisplayScale(g2d);
 
         {
             var rootFrame = frames.get(0);
-            rectOnCanvas.x = (int) (flameGraphWidth * rootFrame.startX) + internalPadding;
-            rectOnCanvas.width = ((int) (flameGraphWidth * rootFrame.endX)) - rectOnCanvas.x - internalPadding;
+            rect.x = (int) (flameGraphWidth * rootFrame.startX) + internalPadding;
+            rect.width = ((int) (flameGraphWidth * rootFrame.endX)) - rect.x - internalPadding;
+            rect.y = frameBoxHeight * rootFrame.stackDepth;
+            rect.height = frameBoxHeight;
 
-            rectOnCanvas.y = frameBoxHeight * rootFrame.stackDepth;
-            rectOnCanvas.height = frameBoxHeight;
-
-            if (visibleRect.intersects(rectOnCanvas)) {
-                paintRootFrameRectangle(g2d, rectOnCanvas,
-                                        rootFrameToText.apply(rootFrame.actualNode),
-                                        handleFocus(frameColorFunction.apply(rootFrame.actualNode),
-                                                    hoveredFrame == rootFrame,
-                                                    false,
-                                                    selectedFrame != null && rootFrame.stackDepth < selectedFrame.stackDepth, minimapMode),
-                                        frameGapColor,
-                                        minimapMode);
+            if (viewRect.intersects(rect)) {
+                paintRootFrameRectangle(g2d, rect,
+                        rootFrameToText.apply(rootFrame.actualNode),
+                        handleFocus(frameColorFunction.apply(rootFrame.actualNode),
+                                hoveredFrame == rootFrame,
+                                false,
+                                selectedFrame != null && rootFrame.stackDepth < selectedFrame.stackDepth),
+                        frameGapColor,
+                        minimapMode);
             }
         }
 
@@ -184,64 +170,64 @@ public class FlameGraphPainter<T> {
             var frame = frames.get(i);
             // TODO Can we do cheaper checks like depth is outside range etc
 
-            rectOnCanvas.x = (int) (flameGraphWidth * frame.startX) + internalPadding;
-            rectOnCanvas.width = ((int) (flameGraphWidth * frame.endX)) - rectOnCanvas.x - internalPadding;
+            rect.x = (int) (flameGraphWidth * frame.startX) + internalPadding;
+            rect.width = ((int) (flameGraphWidth * frame.endX)) - rect.x - internalPadding;
 
-            if ((rectOnCanvas.width < frameWidthVisibilityThreshold) && !minimapMode) {
+            if ((rect.width < frameWidthVisibilityThreshold) && !minimapMode) {
                 continue;
             }
 
-            rectOnCanvas.y = frameBoxHeight * frame.stackDepth;
-            rectOnCanvas.height = frameBoxHeight;
+            rect.y = frameBoxHeight * frame.stackDepth;
+            rect.height = frameBoxHeight;
 
-            if (visibleRect.intersects(rectOnCanvas)) {
-                paintNodeFrameRectangle(g2d, rectOnCanvas,
-                                        frame.actualNode,
-                                        handleFocus(frameColorFunction.apply(frame.actualNode),
-                                                    hoveredFrame == frame,
-                                                    false,
-                                                    selectedFrame != null && (
-                                                            frame.stackDepth < selectedFrame.stackDepth
-                                                            || frame.endX <= selectedFrame.startX
-                                                            || frame.startX >= selectedFrame.endX),
-                                                    minimapMode),
-                                        frameGapColor,
-                                        minimapMode);
+            if (viewRect.intersects(rect)) {
+                paintNodeFrameRectangle(g2d, rect,
+                        frame.actualNode,
+                        handleFocus(frameColorFunction.apply(frame.actualNode),
+                                hoveredFrame == frame,
+                                false,
+                                selectedFrame != null && (
+                                        frame.stackDepth < selectedFrame.stackDepth
+                                                || frame.endX <= selectedFrame.startX
+                                                || frame.startX >= selectedFrame.endX)),
+                        frameGapColor,
+                        minimapMode);
             }
         }
 
         if (!minimapMode) {
-            paintHoveredFrameBorder(g2d, visibleRect, frameBoxHeight, rectOnCanvas);
+            paintHoveredFrameBorder(g2d, bounds, viewRect, frameBoxHeight, rect);
         }
 
         if (!minimapMode && paintDetails) {
             // timestamp
-            var drawTimeMs = "FrameGraph width " + flameGraphWidth + " Zoom Factor " + zoomFactor + " Coordinate (" + visibleRect.x + ", " + visibleRect.y + ") size (" +
-                             visibleRect.width + ", " + visibleRect.height +
-                             ") , Draw time: " + (System.currentTimeMillis() - start) + " ms";
+            var zoomFactor = bounds.getWidth() / viewRect.getWidth();
+            var drawTimeMs = "FrameGraph width " + flameGraphWidth + " Zoom Factor " + zoomFactor + " Coordinate (" + viewRect.getX() + ", " + viewRect.getY() + ") size (" +
+                    viewRect.getWidth() + ", " + viewRect.getHeight() +
+                    ") , Draw time: " + (System.currentTimeMillis() - start) + " ms";
             var nowWidth = g2d.getFontMetrics().stringWidth(drawTimeMs);
             g2d.setColor(Color.DARK_GRAY);
-            g2d.fillRect(visibleRect.x + visibleRect.width - nowWidth - textBorder * 2,
-                        visibleRect.y + visibleRect.height - frameBoxHeight,
-                        nowWidth + textBorder * 2,
-                        frameBoxHeight);
+            g2d.fillRect((int) (viewRect.getX() + viewRect.getWidth() - nowWidth - textBorder * 2),
+                    (int) (viewRect.getY() + viewRect.getHeight() - frameBoxHeight),
+                    nowWidth + textBorder * 2,
+                    frameBoxHeight);
 
             g2d.setColor(Color.YELLOW);
             g2d.drawString(drawTimeMs,
-                          visibleRect.x + visibleRect.width - nowWidth - textBorder,
-                          visibleRect.y + visibleRect.height - textBorder);
+                    (int) (viewRect.getX() + viewRect.getWidth() - nowWidth - textBorder),
+                    (int) (viewRect.getY() + viewRect.getHeight() - textBorder));
         }
 
         g2d.dispose();
     }
 
-    private void paintHoveredFrameBorder(Graphics2D g2, Rectangle visibleRect, int frameBoxHeight, Rectangle rect) {
+    private void paintHoveredFrameBorder(Graphics2D g2, Rectangle2D bounds, Rectangle2D viewRect, int frameBoxHeight, Rectangle rect) {
         if (hoveredFrame == null || !paintHoveredFrameBorder) {
             return;
         }
 
-        rect.x = (int) (flameGraphWidth * hoveredFrame.startX) + internalPadding;
-        rect.width = ((int) (flameGraphWidth * hoveredFrame.endX)) - rect.x - internalPadding - frameBorderWidth;
+        rect.x = (int) (bounds.getWidth() * hoveredFrame.startX) + internalPadding;
+        rect.width = ((int) (bounds.getWidth() * hoveredFrame.endX)) - rect.x - internalPadding - frameBorderWidth;
 
         if ((rect.width < frameWidthVisibilityThreshold)) {
             return;
@@ -250,7 +236,7 @@ public class FlameGraphPainter<T> {
         rect.y = frameBoxHeight * hoveredFrame.stackDepth;
         rect.height = frameBoxHeight - frameGapWidth;
 
-        if (visibleRect.intersects(rect)) {
+        if (viewRect.intersects(rect)) {
             g2.setColor(frameBorderColor);
             g2.setStroke(frameBorderStroke);
             g2.draw(rect);
@@ -267,10 +253,7 @@ public class FlameGraphPainter<T> {
         //                          scaleY = transform.getScaleY());
     }
 
-    private Color handleFocus(Color bgColor, boolean hovered, boolean highlighted, boolean dimmed, boolean minimapMode) {
-        if (minimapMode) {
-            return bgColor;
-        }
+    private Color handleFocus(Color bgColor, boolean hovered, boolean highlighted, boolean dimmed) {
         if (dimmed) {
             return Colors.blend(bgColor, Colors.translucent_black_B0);
         }
@@ -328,54 +311,43 @@ public class FlameGraphPainter<T> {
         return frameRect;
     }
 
-    public Optional<FrameBox<T>> getFrameAt(Graphics2D g2, Point point) {
+    public Optional<FrameBox<T>> getFrameAt(Graphics2D g2, Rectangle2D bounds, Point point) {
         int depth = point.y / getFrameBoxHeight(g2);
-        double xLocation = ((double) point.x) / flameGraphWidth;
+        double xLocation = point.x / bounds.getWidth();
 
         return frames.stream()
                      .filter(node -> node.stackDepth == depth && node.startX <= xLocation && xLocation <= node.endX)
                      .findFirst();
     }
 
-    public void toggleSelectedFrameAt(Graphics2D g2, Point point) {
-        getFrameAt(
-                g2,
-                point
-        ).ifPresent(frame -> selectedFrame = selectedFrame == frame ? null : frame);
+    public void toggleSelectedFrameAt(Graphics2D g2, Rectangle2D bounds, Point point) {
+        getFrameAt(g2, bounds, point)
+                .ifPresent(frame -> selectedFrame = selectedFrame == frame ? null : frame);
     }
 
-    public void hoverFrameAt(Graphics2D g2, Point point, Consumer<FrameBox<T>> hoverConsumer) {
-        getFrameAt(
-                g2,
-                point
-        ).ifPresentOrElse(frame -> {
-                              hoveredFrame = frame;
-                              if (hoverConsumer != null) {
-                                  hoverConsumer.accept(frame);
-                              }
-                          },
-                          this::stopHover);
+    public void hoverFrameAt(Graphics2D g2, Rectangle2D bounds, Point point, Consumer<FrameBox<T>> hoverConsumer) {
+        getFrameAt(g2, bounds, point)
+                .ifPresentOrElse(frame -> {
+                            hoveredFrame = frame;
+                            if (hoverConsumer != null) {
+                                hoverConsumer.accept(frame);
+                            }
+                        },
+                        this::stopHover);
     }
 
-    public Optional<Point> zoomToFrameAt(Graphics2D g2, Point point) {
-        return getFrameAt(
-                g2,
-                point
-        ).map(frame -> {
+    public Optional<ZoomTarget> calculateZoomTargetForFrameAt(Graphics2D g2, Rectangle2D bounds, Rectangle2D viewRect, Point point) {
+        return getFrameAt(g2, bounds, point).map(frame -> {
             this.selectedFrame = frame;
 
             var frameWidthX = frame.endX - frame.startX;
-            flameGraphWidth = (int) Math.max(visibleWidth / Math.min(1, frameWidthX), visibleWidth);
-            zoomFactor = (double) flameGraphWidth / visibleWidth;
-
             var frameBoxHeight = getFrameBoxHeight(g2);
             int y = frameBoxHeight * frame.stackDepth;
 
             // Change offset to center the flame from this frame
-            return new Point(
-                    (int) (frame.startX * flameGraphWidth),
-                    Math.max(0, y)
-            );
+            double factor = (1.0 / frameWidthX) * (viewRect.getWidth() / bounds.getWidth());
+            return new ZoomTarget(new Dimension((int) (bounds.getWidth() * factor), (int) (bounds.getHeight() * factor)),
+                    new Point((int) (frame.startX * bounds.getWidth() * factor), Math.max(0, y)));
         });
     }
 
@@ -387,21 +359,21 @@ public class FlameGraphPainter<T> {
         var metrics = g2.getFontMetrics();
 
         nodeToTextCandidates.stream()
-                            .map(f -> f.apply(node))
-                            .filter(text -> {
-                                var textBounds = metrics.getStringBounds(text, g2);
-                                return !(textBounds.getWidth() > targetWidth);
-                            })
-                            .findFirst()
-                            .ifPresentOrElse(
-                                    textConsumer,
-                                    () -> {
-                                        var textBounds = metrics.getStringBounds("...", g2);
-                                        if (!(textBounds.getWidth() > targetWidth)) {
-                                            textConsumer.accept("...");
-                                        }
-                                    }
-                            );
+                .map(f -> f.apply(node))
+                .filter(text -> {
+                    var textBounds = metrics.getStringBounds(text, g2);
+                    return !(textBounds.getWidth() > targetWidth);
+                })
+                .findFirst()
+                .ifPresentOrElse(
+                        textConsumer,
+                        () -> {
+                            var textBounds = metrics.getStringBounds("...", g2);
+                            if (!(textBounds.getWidth() > targetWidth)) {
+                                textConsumer.accept("...");
+                            }
+                        }
+                );
     }
 
     private static void paintFrameText(String text, Graphics2D g2, double targetWidth, Consumer<String> textConsumer) {

--- a/fireplace-swing/src/main/java/io/github/bric3/fireplace/flamegraph/ZoomTarget.java
+++ b/fireplace-swing/src/main/java/io/github/bric3/fireplace/flamegraph/ZoomTarget.java
@@ -1,0 +1,32 @@
+/*
+ * Fireplace
+ *
+ * Copyright (c) 2021, Today - Brice Dutheil
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package io.github.bric3.fireplace.flamegraph;
+
+import java.awt.*;
+
+/**
+ * Represents a target for zooming.
+ */
+public class ZoomTarget {
+
+    public Dimension bounds;
+
+    public Point viewOffset;
+
+    public ZoomTarget(Dimension bounds, Point viewOffset) {
+        this.bounds = bounds;
+        this.viewOffset = viewOffset;
+    }
+
+    public String toString() {
+        return "[bounds=" + bounds + ",offset=" + viewOffset + "]";
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,12 +14,14 @@ darklaf = "2.7.3"
 graalvm = "22.0.0.2"
 junit-jupiter = "5.8.2"
 jmc-flightrecorder = "8.1.0"
+radiance-animation = "5.0.0"
 
 [libraries]
 flatlaf = { module = "com.formdev:flatlaf", version.ref = "flatlaf" }
 flatlaf-extras = { module = "com.formdev:flatlaf-extras", version.ref = "flatlaf" }
 darklaf = { module = "com.github.weisj:darklaf-core", version.ref = "darklaf" }
 flightrecorder = { module = "org.openjdk.jmc:flightrecorder", version.ref = "jmc-flightrecorder" }
+radianceanimation = { module = "org.pushing-pixels:radiance-animation", version.ref = "radiance-animation" }
 
 graal-sdk = { module = "org.graalvm.sdk:graal-sdk", version.ref = "graalvm" }
 graal-js = { module = "org.graalvm.js:js", version.ref = "graalvm" }


### PR DESCRIPTION
Adds an animated transition between frames upon double-click, using the Radiance animation library (https://github.com/kirill-grouchnikov/radiance).  To make this work, a small refactoring has been done to remove state from the `FrameGraphPainter` (specifically `flameGraphWidth` and `visibleWidth`) that can more easily be passed to the paint methods when called.

To test this PR, run the main app, load a JFR file and double-click on some frames.