### PR TITLE
fix: The frame box height is incorrectly set.

### DIFF
--- a/fireplace-swing/src/main/java/io/github/bric3/fireplace/flamegraph/FlameGraphPainter.java
+++ b/fireplace-swing/src/main/java/io/github/bric3/fireplace/flamegraph/FlameGraphPainter.java
@@ -676,7 +676,7 @@ class FlameGraphPainter<T> {
     ) {
         var frameWidthX = frame.endX - frame.startX;
         var frameBoxHeight = getFrameBoxHeight(g2);
-        int y = frameBoxHeight * (Math.min(frame.stackDepth - contextBefore, 0));
+        int y = frameBoxHeight * (Math.max(frame.stackDepth - contextBefore, 0));
 
         /*
          * The new scale factor is


### PR DESCRIPTION
This fixes https://github.com/bric3/fireplace/issues/62 where zooming to a frame did not adjust the vertical position correctly.