### PR TITLE
refactor(flamegraph): maintain zoom scale and anchor

### DIFF
--- a/fireplace-app/src/main/java/io/github/bric3/fireplace/FirePlaceMain.java
+++ b/fireplace-app/src/main/java/io/github/bric3/fireplace/FirePlaceMain.java
@@ -110,7 +110,7 @@ public class FirePlaceMain {
             {
                 jTabbedPane.addTab(SYSTEM_PROPERTIES, JScrollPaneWithButton.create(() -> new JScrollPane(sysProps)));
                 jTabbedPane.addTab(NATIVE_LIBRARIES, JScrollPaneWithButton.create(() -> new JScrollPane(nativeLibs)));
-                jTabbedPane.addTab(ALLOCATIONS, allocationFlameGraphPanel);
+                // jTabbedPane.addTab(ALLOCATIONS, allocationFlameGraphPanel);
                 jTabbedPane.addTab(CPU, cpuFlameGraphPanel);
                 jTabbedPane.setTabPlacement(JTabbedPane.BOTTOM);
             }

--- a/fireplace-app/src/main/java/io/github/bric3/fireplace/FlameGraphTab.java
+++ b/fireplace-app/src/main/java/io/github/bric3/fireplace/FlameGraphTab.java
@@ -18,6 +18,7 @@ import io.github.bric3.fireplace.flamegraph.FlamegraphView;
 import io.github.bric3.fireplace.flamegraph.FrameFontProvider;
 import io.github.bric3.fireplace.flamegraph.FrameTextsProvider;
 import io.github.bric3.fireplace.flamegraph.ZoomAnimation;
+import io.github.bric3.fireplace.ui.BalloonToolTip;
 import org.openjdk.jmc.common.util.FormatToolkit;
 import org.openjdk.jmc.flightrecorder.stacktrace.tree.Node;
 import org.openjdk.jmc.flightrecorder.stacktrace.tree.StacktraceTreeModel;
@@ -49,7 +50,7 @@ public class FlameGraphTab extends JPanel {
         jfrFlamegraphView.showMinimap(defaultShowMinimap);
         jfrFlamegraphView.configureCanvas(ToolTipManager.sharedInstance()::registerComponent);
         jfrFlamegraphView.putClientProperty(FlamegraphView.SHOW_STATS, true);
-        // jfrFlameGraph.setTooltipComponentSupplier(BalloonToolTip::new);
+        jfrFlamegraphView.setTooltipComponentSupplier(BalloonToolTip::new);
         var minimapShade = new DarkLightColor(Colors.translucent_white_80, Colors.translucent_black_40);
         jfrFlamegraphView.setMinimapShadeColorSupplier(() -> minimapShade);
         var zoomAnimation = new ZoomAnimation();
@@ -147,14 +148,14 @@ public class FlameGraphTab extends JPanel {
                     var matches = jfrFlamegraphView.getFrames()
                                                    .stream()
                                                    .filter(frame -> {
-                                                   var method = frame.actualNode.getFrame().getMethod();
-                                                   return method.getMethodName().contains(searched)
-                                                          || method.getType().getTypeName().contains(searched)
-                                                          || (method.getType().getPackage().getName() != null && method.getType().getPackage().getName().contains(searched))
-                                                          || (method.getType().getPackage().getModule() != null && method.getType().getPackage().getModule().getName().contains(searched))
-                                                          || method.getFormalDescriptor().replace('/', '.').contains(searched)
-                                                           ;
-                                               })
+                                                       var method = frame.actualNode.getFrame().getMethod();
+                                                       return method.getMethodName().contains(searched)
+                                                              || method.getType().getTypeName().contains(searched)
+                                                              || (method.getType().getPackage().getName() != null && method.getType().getPackage().getName().contains(searched))
+                                                              || (method.getType().getPackage().getModule() != null && method.getType().getPackage().getModule().getName().contains(searched))
+                                                              || method.getFormalDescriptor().replace('/', '.').contains(searched)
+                                                               ;
+                                                   })
                                                    .collect(Collectors.toCollection(() -> Collections.newSetFromMap(new IdentityHashMap<>())));
                     jfrFlamegraphView.highlightFrames(matches, searched);
                 } catch (Exception ex) {
@@ -179,7 +180,7 @@ public class FlameGraphTab extends JPanel {
         add(controlPanel, BorderLayout.NORTH);
         add(wrapper, BorderLayout.CENTER);
     }
-    
+
     public void setStacktraceTreeModel(StacktraceTreeModel stacktraceTreeModel) {
         dataApplier = dataApplier(stacktraceTreeModel);
         dataApplier.accept(jfrFlamegraphView);
@@ -204,7 +205,7 @@ public class FlameGraphTab extends JPanel {
                         frame -> frame.isRoot() ? "" : FormatToolkit.getHumanReadable(frame.actualNode.getFrame().getMethod(), false, false, false, false, true, false),
                         frame -> frame.isRoot() ? "" : frame.actualNode.getFrame().getMethod().getMethodName()
                 ),
-                new DimmingFrameColorProvider(defaultFrameColorMode.colorMapperUsing(ColorMapper.ofObjectHashUsing(defaultColorPalette.colors()))),
+                new DimmingFrameColorProvider<>(defaultFrameColorMode.colorMapperUsing(ColorMapper.ofObjectHashUsing(defaultColorPalette.colors()))),
                 FrameFontProvider.defaultFontProvider(),
                 frame -> {
                     if (frame.isRoot()) {
@@ -226,6 +227,8 @@ public class FlameGraphTab extends JPanel {
                            + desc + "<br><hr>"
                            + frame.actualNode.getCumulativeWeight() + " " + frame.actualNode.getWeight() + "<br>"
                            + "BCI: " + frame.actualNode.getFrame().getBCI() + " Line number: " + frame.actualNode.getFrame().getFrameLineNumber() + "<br>"
+                           + frame.startX + ":" + frame.endX + "<br>"
+                           + "location: " + flameGraph.getFrameLocation(frame) + "<br>"
                            + "</html>";
                 }
         );

--- a/fireplace-swing/src/main/java/io/github/bric3/fireplace/flamegraph/FlamegraphRenderEngine.java
+++ b/fireplace-swing/src/main/java/io/github/bric3/fireplace/flamegraph/FlamegraphRenderEngine.java
@@ -318,10 +318,12 @@ class FlamegraphRenderEngine<T> {
      * Creates and returns the bounds for the specified frame, assuming that the whole flame graph is to
      * be rendered within the specified {@code bounds}.
      *
+     * This method includes the gap on each sides of the frame.
+     *
      * @param g2     the graphics target ({@code null} not permitted).
      * @param bounds the flame graph bounds ({@code null} not permitted)
      * @param frame  the frame ({@code null} not permitted)
-     * @return The bounds for the specified frame.
+     * @return The bounds for the specified frame (including the gap).
      */
     public Rectangle getFrameRectangle(
             Graphics2D g2,
@@ -329,6 +331,7 @@ class FlamegraphRenderEngine<T> {
             FrameBox<T> frame
     ) {
         // TODO delegate to frame renderer ?
+        // TODO get rectangle without gap ?
 
         var frameBoxHeight = frameRenderer.getFrameBoxHeight(g2);
         var frameGapWidth = frameRenderer.getFrameGapWidth();
@@ -470,6 +473,7 @@ class FlamegraphRenderEngine<T> {
         double factor = getScaleFactor(viewRect.getWidth(), bounds.getWidth(), frameWidthX);
         // Change offset to center the flame from this frame
         return new ZoomTarget(
+                factor,
                 new Dimension(
                         (int) (bounds.getWidth() * factor),
                         (int) (bounds.getHeight() * factor)

--- a/fireplace-swing/src/main/java/io/github/bric3/fireplace/flamegraph/ZoomTarget.java
+++ b/fireplace-swing/src/main/java/io/github/bric3/fireplace/flamegraph/ZoomTarget.java
@@ -17,23 +17,30 @@ import java.util.Objects;
  * Represents a target for zooming.
  */
 public class ZoomTarget {
+    /** The 1:1 scale */
+    public static final double SCALE_1 = 1d;
+
+    /** The scale factor for this zoom target */
+    public final double scaleFactor;
 
     /** The bounds required to draw the whole content. */
-    public Dimension bounds;
+    public final Dimension canvasBounds;
 
     /** The coordinates of the top-left corner of the frame that is the target of the zoom. */
-    public Point viewOffset;
+    public final Point viewOffset;
 
     /**
      * Creates a new zoom target.
      *
-     * @param bounds     the bounds.
-     * @param viewOffset the view offset.
+     * @param scaleFactor
+     * @param canvasBounds      the bounds.
+     * @param viewOffset  the view offset.
      */
-    public ZoomTarget(Dimension bounds, Point viewOffset) {
-        Objects.requireNonNull(bounds);
+    public ZoomTarget(double scaleFactor, Dimension canvasBounds, Point viewOffset) {
+        this.scaleFactor = scaleFactor;
+        Objects.requireNonNull(canvasBounds);
         Objects.requireNonNull(viewOffset);
-        this.bounds = bounds;
+        this.canvasBounds = canvasBounds;
         this.viewOffset = viewOffset;
     }
 
@@ -45,8 +52,8 @@ public class ZoomTarget {
     @Override
     public String toString() {
         return "ZoomTarget{" +
-                "bounds=" + bounds +
-                ", viewOffset=" + viewOffset +
-                '}';
+               "bounds=" + canvasBounds +
+               ", viewOffset=" + viewOffset +
+               '}';
     }
 }


### PR DESCRIPTION
This PR aim to maintain the scale upon component resize, while maintaining the scale.

Currently does not achieve its goal. I tried two approaches to react to resize :

1. register a `ComponentListener::componentResized` when the viewport is resized, then calculate the new anchor point and set it as view position.
2. trigger a task when `FlamegraphCanvas::getPreferredSize` is invoked, this task calculate the new anchor point and set it as view position.

Somehow the view flickers its position, but ultimately the new anchor position is drifting for an unknown reason. The math looks correct so there must be something else there.

Not sure how to address the issue.

Also

- [ ] this break again the visible height/depth fix done in ff468005b8dc6c16798fc7ec693dd287d2640ed9

Should fix #46