### PR TITLE
feature(flamegraph): Show hovered frame siblings

### DIFF
--- a/fireplace-app/src/main/java/io/github/bric3/fireplace/FlameGraphTab.java
+++ b/fireplace-app/src/main/java/io/github/bric3/fireplace/FlameGraphTab.java
@@ -16,6 +16,7 @@ import io.github.bric3.fireplace.flamegraph.ColorMapper;
 import io.github.bric3.fireplace.flamegraph.DimmingFrameColorProvider;
 import io.github.bric3.fireplace.flamegraph.FlamegraphView;
 import io.github.bric3.fireplace.flamegraph.FrameFontProvider;
+import io.github.bric3.fireplace.flamegraph.FrameModel;
 import io.github.bric3.fireplace.flamegraph.FrameTextsProvider;
 import io.github.bric3.fireplace.flamegraph.ZoomAnimation;
 import io.github.bric3.fireplace.ui.BalloonToolTip;
@@ -30,6 +31,7 @@ import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.util.Collections;
 import java.util.IdentityHashMap;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -211,7 +213,10 @@ public class FlameGraphTab extends JPanel {
     private Consumer<FlamegraphView<Node>> dataApplier(StacktraceTreeModel stacktraceTreeModel) {
         var flatFrameList = JfrFrameNodeConverter.convert(stacktraceTreeModel);
         return (flameGraph) -> flameGraph.setConfigurationAndData(
-                flatFrameList,
+                new FrameModel<>(
+                        (a, b) -> Objects.equals(a.actualNode.getFrame(), b.actualNode.getFrame()),
+                        flatFrameList
+                ),
                 FrameTextsProvider.of(
                         frame -> {
                             if (frame.isRoot()) {

--- a/fireplace-swing/src/main/java/io/github/bric3/fireplace/core/ui/Colors.java
+++ b/fireplace-swing/src/main/java/io/github/bric3/fireplace/core/ui/Colors.java
@@ -433,6 +433,104 @@ public class Colors {
         );
     }
 
+    private static final float DARKER_FACTOR = 0.7f;
+    private static final float BRIGHTER_FACTOR = 1 / DARKER_FACTOR;
+
+    /**
+     * Brighten a color by lowering the luminance.
+     *
+     * <p>
+     * This differs from {@link Color#brighter()} as it computes
+     * the value in the HSL space, also this method takes a {@code factor},
+     * which is similar to applying {@link Color#brighter()} multiple times,
+     * but without creating new objects.
+     * </p>
+     *
+     * @param color The color to brighten.
+     * @param k     The factor, min value 0.
+     * @return The brightened color.
+     * @see #darker(Color, float)
+     */
+    public static Color brighter(Color color, float k) {
+        return brighter(color, k, 1f);
+    }
+
+    /**
+     * Brighten a color by lowering the luminance.
+     *
+     * <p>
+     * This differs from {@link Color#brighter()} as it computes
+     * the value in the HSL space, also this method takes a {@code factor},
+     * which is similar to applying {@link Color#brighter()} multiple times,
+     * but without creating new objects.
+     * </p>
+     *
+     * @param color        The color to brighten.
+     * @param k            The factor, min value 0.
+     * @param maxLuminance The higher bound for the luminance [0; 1].
+     * @return The brightened color.
+     * @see #darker(Color, float, float)
+     */
+    public static Color brighter(Color color, float k, float maxLuminance) {
+        checkThat(k < 0, "k must be positive");
+        checkThat(maxLuminance < 0 || maxLuminance > 1, "maxLuminance [0; 1], actual: " + maxLuminance);
+        double factor = k == 0f ? BRIGHTER_FACTOR : Math.pow(BRIGHTER_FACTOR, k);
+        var hsla = hslaComponents(color);
+        return hsla(
+                hsla[H],
+                hsla[S],
+                Math.min((float) (hsla[L] * factor), maxLuminance),
+                hsla[ALPHA]
+        );
+    }
+
+    /**
+     * Darken a color by lowering the luminance.
+     *
+     * <p>
+     * This differs from {@link Color#darker()} as it computes
+     * the value in the HSL space, also this method takes a {@code factor},
+     * which is similar to applying {@link Color#darker()}multiple times,
+     * but without creating new objects.
+     * </p>
+     *
+     * @param color The color to darken.
+     * @param k     The factor, min value 0.
+     * @return The darkened color.
+     * @see #brighter(Color, float)
+     */
+    public static Color darker(Color color, float k) {
+        return darker(color, k, 0f);
+    }
+
+    /**
+     * Darken a color by lowering the luminance.
+     *
+     * <p>
+     * This differs from {@link Color#darker()} as it computes
+     * the value in the HSL space, also this method takes a {@code factor},
+     * which is similar to applying {@link Color#darker()}multiple times,
+     * but without creating new objects.
+     * </p>
+     *
+     * @param color        The color to darken.
+     * @param k            The factor, min value 0.
+     * @param minLuminance The lower bound for the luminance [0; 1].
+     * @return The darkened color.
+     * @see #brighter(Color, float, float)
+     */
+    public static Color darker(Color color, float k, float minLuminance) {
+        checkThat(k < 0, "k must be positive");
+        checkThat(minLuminance < 0 || minLuminance > 1, "maxLuminance [0; 1], actual: " + minLuminance);
+        double factor = k == 0f ? DARKER_FACTOR : Math.pow(DARKER_FACTOR, k);
+        var hsla = hslaComponents(color);
+        return hsla(
+                hsla[H],
+                hsla[S],
+                Math.max((float) (hsla[L] * factor), minLuminance),
+                hsla[ALPHA]
+        );
+    }
 
     /**
      * Convert an RGB Color to its corresponding HSL components and alpha channel.

--- a/fireplace-swing/src/main/java/io/github/bric3/fireplace/core/ui/Colors.java
+++ b/fireplace-swing/src/main/java/io/github/bric3/fireplace/core/ui/Colors.java
@@ -21,17 +21,21 @@ import java.util.regex.Pattern;
  */
 public class Colors {
     /**
-     * Hue
+     * Hue value position
+     *
+     * @see #hslComponents(Color)
      */
     public static final int H = 0;
     /**
-     * Saturation
+     * Saturation value position
      */
     public static final int S = 1;
     /**
-     * Luminance
+     * Luminance value position
+     *
+     * @see #hslComponents(Color)
      */
-    public static final int L = 2;
+    private static final int L = 2;
     private static volatile boolean darkMode = false;
 
     /**
@@ -117,7 +121,7 @@ public class Colors {
     public static Color panelForeground = UIManager.getColor("Panel.foreground");
 
     /**
-     * Refresh the colors when the LaF changes
+     * Refresh the colors, usually done when the LaF changes.
      */
     public static void refreshColors() {
         panelBackground = UIManager.getColor("Panel.background");
@@ -417,14 +421,14 @@ public class Colors {
         }
 
         return new DarkLightColor(
-                hsl(hslLight[0], hslLight[1], hslLight[2], color.getAlpha() / 255.0f),
-                hsl(hslDark[0], hslDark[1], hslDark[2], color.getAlpha() / 255.0f)
+                hsl(hslLight[H], hslLight[S], hslLight[L], color.getAlpha() / 255.0f),
+                hsl(hslDark[H], hslDark[S], hslDark[L], color.getAlpha() / 255.0f)
         );
     }
 
 
     /**
-     * Convert an RGB Color to it corresponding HSL components.
+     * Convert an RGB Color to its corresponding HSL components.
      * <p>
      * From <a href="https://github.com/d3/d3-color/blob/958249d3a17aaff499d2a9fc9a0f7b8b8e8a47c8/src/color.js">d3-colors</a>.
      *

--- a/fireplace-swing/src/main/java/io/github/bric3/fireplace/flamegraph/DimmingFrameColorProvider.java
+++ b/fireplace-swing/src/main/java/io/github/bric3/fireplace/flamegraph/DimmingFrameColorProvider.java
@@ -44,6 +44,7 @@ import static io.github.bric3.fireplace.flamegraph.FrameRenderingFlags.isFocusin
 import static io.github.bric3.fireplace.flamegraph.FrameRenderingFlags.isHighlightedFrame;
 import static io.github.bric3.fireplace.flamegraph.FrameRenderingFlags.isHighlighting;
 import static io.github.bric3.fireplace.flamegraph.FrameRenderingFlags.isHovered;
+import static io.github.bric3.fireplace.flamegraph.FrameRenderingFlags.isHoveredSibling;
 import static io.github.bric3.fireplace.flamegraph.FrameRenderingFlags.isMinimapMode;
 
 public class DimmingFrameColorProvider<T> implements FrameColorProvider<T> {
@@ -52,10 +53,15 @@ public class DimmingFrameColorProvider<T> implements FrameColorProvider<T> {
             Colors.rgba(255, 255, 255, 0.51f)
     );
 
+    public static final Color HOVERED_NODE = new DarkLightColor(
+            new Color(0xFFE0C268, true),
+            new Color(0xD0E0C268, true)
+    );
+
     public static final Color ROOT_NODE = new DarkLightColor(
-            new Color(0xffeaf6fc),
-            new Color(0xff091222)
-            );
+            new Color(0xFFEAF6FC),
+            new Color(0xFF091222)
+    );
     private final Function<FrameBox<T>, Color> baseColorFunction;
     private final ColorModel reusedColorModelForMainCanvas = new ColorModel(null, null);
     private final ColorModel reusedColorModelForMinimap = new ColorModel(null, null);
@@ -91,8 +97,9 @@ public class DimmingFrameColorProvider<T> implements FrameColorProvider<T> {
             foreground = Colors.foregroundColor(backgroundColor);
         }
 
-        if (isHovered(flags)) {
-            backgroundColor = Colors.blend(backgroundColor, Colors.translucent_black_40);
+        if (isHovered(flags) || isHoveredSibling(flags)) {
+            backgroundColor = Colors.blend(backgroundColor, HOVERED_NODE);
+            foreground = Colors.foregroundColor(backgroundColor);
         }
 
         return reusedColorModelForMainCanvas.set(
@@ -103,12 +110,12 @@ public class DimmingFrameColorProvider<T> implements FrameColorProvider<T> {
 
     /**
      * Dim only if not highlighted or not focused
-     *
+     * <p>
      * - highlighting and not highlighted => dim
      * - focusing and not focused => dim
      * - highlighting and focusing
-     *    - highlighted => nope
-     *    - focusing => nope
+     * - highlighted => nope
+     * - focusing => nope
      */
     private boolean shouldDim(int flags) {
         var highlighting = isHighlighting(flags);

--- a/fireplace-swing/src/main/java/io/github/bric3/fireplace/flamegraph/DimmingFrameColorProvider.java
+++ b/fireplace-swing/src/main/java/io/github/bric3/fireplace/flamegraph/DimmingFrameColorProvider.java
@@ -36,6 +36,7 @@ import io.github.bric3.fireplace.core.ui.Colors;
 import io.github.bric3.fireplace.core.ui.DarkLightColor;
 
 import java.awt.*;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
@@ -47,31 +48,68 @@ import static io.github.bric3.fireplace.flamegraph.FrameRenderingFlags.isHovered
 import static io.github.bric3.fireplace.flamegraph.FrameRenderingFlags.isHoveredSibling;
 import static io.github.bric3.fireplace.flamegraph.FrameRenderingFlags.isMinimapMode;
 
+/**
+ * Frame color provider that supports frame dimming and hovering.
+ *
+ * <p>
+ * This frame color provider is responsible for computing the color of a frame.
+ * It uses the actual frame and passes it to a basic <em>color function</em>
+ * that will apply the actual base background color to the frame.
+ * </p>
+ *
+ * <p>
+ * Then this base color can be altered or changed depending on the frame's
+ * flags.
+ * </p>
+ *
+ * @param <T> The actual type of frame.
+ */
 public class DimmingFrameColorProvider<T> implements FrameColorProvider<T> {
-    public static final Color DIMMED_TEXT = new DarkLightColor(
+    public static final Color DIMMED_TEXT_COLOR = new DarkLightColor(
             Colors.rgba(28, 43, 52, 0.68f),
             Colors.rgba(255, 255, 255, 0.51f)
     );
 
-    public static final Color HOVERED_NODE = new DarkLightColor(
+    public static final Color HOVERED_BACKGROUND_COLOR = new DarkLightColor(
             new Color(0xFFE0C268, true),
             new Color(0xD0E0C268, true)
     );
 
-    public static final Color ROOT_NODE = new DarkLightColor(
+    public static final Color ROOT_BACKGROUND_COLOR = new DarkLightColor(
             new Color(0xFFEAF6FC),
             new Color(0xFF091222)
     );
     private final Function<FrameBox<T>, Color> baseColorFunction;
+
+    /**
+     * Single instance to avoid too many allocations, only for the main canvas.
+     */
     private final ColorModel reusedColorModelForMainCanvas = new ColorModel(null, null);
+
+    /**
+     * Single instance to avoid too many allocations, only for the minimap.
+     * Since the minimap generation happens on a different thread, it is necessary
+     * to have a separate instance.
+     */
     private final ColorModel reusedColorModelForMinimap = new ColorModel(null, null);
 
     private final ConcurrentHashMap<Color, Color> dimmedColorCache = new ConcurrentHashMap<>();
 
+    private Color rootBackGroundColor = ROOT_BACKGROUND_COLOR;
+    private Color dimmedTextColor = DIMMED_TEXT_COLOR;
+    private Color hoveredBackgroundColor = HOVERED_BACKGROUND_COLOR;
+
+    /**
+     * Builds a basic frame color provider.
+     *
+     * @param baseColorFunction The color function that provides the frame's color.
+     * @see #withRootBackgroundColor(Color)
+     * @see #withDimmedTextColor(Color)
+     * @see #withHoveredBackgroundColor(Color)
+     */
     public DimmingFrameColorProvider(Function<FrameBox<T>, Color> baseColorFunction) {
         this.baseColorFunction = baseColorFunction;
     }
-
 
     @Override
     public ColorModel getColors(FrameBox<T> frame, int flags) {
@@ -80,7 +118,7 @@ public class DimmingFrameColorProvider<T> implements FrameColorProvider<T> {
 
         var rootNode = frame.isRoot();
         if (rootNode) {
-            backgroundColor = ROOT_NODE;
+            backgroundColor = rootBackGroundColor;
         } else {
             backgroundColor = baseColorFunction.apply(frame);
         }
@@ -91,14 +129,19 @@ public class DimmingFrameColorProvider<T> implements FrameColorProvider<T> {
         }
 
         if (!rootNode && shouldDim(flags)) {
-            backgroundColor = cachedDim(backgroundColor);
-            foreground = DIMMED_TEXT;
+            backgroundColor = dimmedBackground(backgroundColor);
+            foreground = dimmedTextColor;
         } else {
             foreground = Colors.foregroundColor(backgroundColor);
         }
 
-        if (isHovered(flags) || isHoveredSibling(flags)) {
-            backgroundColor = Colors.blend(backgroundColor, HOVERED_NODE);
+        if (isHovered(flags)) {
+            backgroundColor = hoverBackground(backgroundColor);
+            foreground = Colors.foregroundColor(backgroundColor);
+        }
+
+        if (isHoveredSibling(flags)) {
+            backgroundColor = hoverSiblingBackground(backgroundColor);
             foreground = Colors.foregroundColor(backgroundColor);
         }
 
@@ -106,6 +149,36 @@ public class DimmingFrameColorProvider<T> implements FrameColorProvider<T> {
                 backgroundColor,
                 foreground
         );
+    }
+
+    /**
+     * Compute the background color for a hovered frame.
+     *
+     * @param backgroundColor The background color of the frame to alter.
+     * @return The hovered background color.
+     */
+    private Color hoverBackground(Color backgroundColor) {
+        return Colors.blend(backgroundColor, hoveredBackgroundColor);
+    }
+
+    /**
+     * Compute the background color for a hovered sibling frame.
+     *
+     * @param backgroundColor The background color of the frame to alter.
+     * @return The hovered background color.
+     */
+    private Color hoverSiblingBackground(Color backgroundColor) {
+        return Colors.blend(backgroundColor, hoveredBackgroundColor);
+    }
+
+    /**
+     * Dims the background color.
+     *
+     * @param backgroundColor The background color to dim.
+     * @return The dimmed color.
+     */
+    protected Color dimmedBackground(Color backgroundColor) {
+        return cachedDim(backgroundColor);
     }
 
     /**
@@ -136,5 +209,20 @@ public class DimmingFrameColorProvider<T> implements FrameColorProvider<T> {
 
     private Color cachedDim(Color color) {
         return dimmedColorCache.computeIfAbsent(color, Colors::dim);
+    }
+
+    public DimmingFrameColorProvider<T> withRootBackgroundColor(Color rootBackgroundColor) {
+        this.rootBackGroundColor = Objects.requireNonNull(rootBackgroundColor);
+        return this;
+    }
+
+    public DimmingFrameColorProvider<T> withDimmedTextColor(Color dimmedTextColor) {
+        this.dimmedTextColor = Objects.requireNonNull(dimmedTextColor);
+        return this;
+    }
+
+    public DimmingFrameColorProvider<T> withHoveredBackgroundColor(Color hoveredBackgroundColor) {
+        this.hoveredBackgroundColor = Objects.requireNonNull(hoveredBackgroundColor);
+        return this;
     }
 }

--- a/fireplace-swing/src/main/java/io/github/bric3/fireplace/flamegraph/DimmingFrameColorProvider.java
+++ b/fireplace-swing/src/main/java/io/github/bric3/fireplace/flamegraph/DimmingFrameColorProvider.java
@@ -70,11 +70,6 @@ public class DimmingFrameColorProvider<T> implements FrameColorProvider<T> {
             Colors.rgba(255, 255, 255, 0.51f)
     );
 
-    public static final Color HOVERED_BACKGROUND_COLOR = new DarkLightColor(
-            new Color(0xFFE0C268, true),
-            new Color(0xD0E0C268, true)
-    );
-
     public static final Color ROOT_BACKGROUND_COLOR = new DarkLightColor(
             new Color(0xFFEAF6FC),
             new Color(0xFF091222)
@@ -97,7 +92,6 @@ public class DimmingFrameColorProvider<T> implements FrameColorProvider<T> {
 
     private Color rootBackGroundColor = ROOT_BACKGROUND_COLOR;
     private Color dimmedTextColor = DIMMED_TEXT_COLOR;
-    private Color hoveredBackgroundColor = HOVERED_BACKGROUND_COLOR;
 
     /**
      * Builds a basic frame color provider.
@@ -105,7 +99,6 @@ public class DimmingFrameColorProvider<T> implements FrameColorProvider<T> {
      * @param baseColorFunction The color function that provides the frame's color.
      * @see #withRootBackgroundColor(Color)
      * @see #withDimmedTextColor(Color)
-     * @see #withHoveredBackgroundColor(Color)
      */
     public DimmingFrameColorProvider(Function<FrameBox<T>, Color> baseColorFunction) {
         this.baseColorFunction = baseColorFunction;
@@ -114,13 +107,14 @@ public class DimmingFrameColorProvider<T> implements FrameColorProvider<T> {
     @Override
     public ColorModel getColors(FrameBox<T> frame, int flags) {
         Color backgroundColor;
+        Color baseBackgroundColor;
         Color foreground;
 
         var rootNode = frame.isRoot();
         if (rootNode) {
-            backgroundColor = rootBackGroundColor;
+            baseBackgroundColor = backgroundColor = rootBackGroundColor;
         } else {
-            backgroundColor = baseColorFunction.apply(frame);
+            baseBackgroundColor = backgroundColor = baseColorFunction.apply(frame);
         }
 
         if (isMinimapMode(flags)) {
@@ -136,12 +130,12 @@ public class DimmingFrameColorProvider<T> implements FrameColorProvider<T> {
         }
 
         if (isHovered(flags)) {
-            backgroundColor = hoverBackground(backgroundColor);
+            backgroundColor = hoverBackground(baseBackgroundColor);
             foreground = Colors.foregroundColor(backgroundColor);
         }
 
         if (isHoveredSibling(flags)) {
-            backgroundColor = hoverSiblingBackground(backgroundColor);
+            backgroundColor = hoverSiblingBackground(baseBackgroundColor);
             foreground = Colors.foregroundColor(backgroundColor);
         }
 
@@ -158,7 +152,9 @@ public class DimmingFrameColorProvider<T> implements FrameColorProvider<T> {
      * @return The hovered background color.
      */
     private Color hoverBackground(Color backgroundColor) {
-        return Colors.blend(backgroundColor, hoveredBackgroundColor);
+        return Colors.isDarkMode() ?
+               Colors.brighter(backgroundColor, 1.1f, 0.95f) :
+               Colors.darker(backgroundColor, 1.25f);
     }
 
     /**
@@ -168,7 +164,7 @@ public class DimmingFrameColorProvider<T> implements FrameColorProvider<T> {
      * @return The hovered background color.
      */
     private Color hoverSiblingBackground(Color backgroundColor) {
-        return Colors.blend(backgroundColor, hoveredBackgroundColor);
+        return hoverBackground(backgroundColor);
     }
 
     /**
@@ -218,11 +214,6 @@ public class DimmingFrameColorProvider<T> implements FrameColorProvider<T> {
 
     public DimmingFrameColorProvider<T> withDimmedTextColor(Color dimmedTextColor) {
         this.dimmedTextColor = Objects.requireNonNull(dimmedTextColor);
-        return this;
-    }
-
-    public DimmingFrameColorProvider<T> withHoveredBackgroundColor(Color hoveredBackgroundColor) {
-        this.hoveredBackgroundColor = Objects.requireNonNull(hoveredBackgroundColor);
         return this;
     }
 }

--- a/fireplace-swing/src/main/java/io/github/bric3/fireplace/flamegraph/FlamegraphRenderEngine.java
+++ b/fireplace-swing/src/main/java/io/github/bric3/fireplace/flamegraph/FlamegraphRenderEngine.java
@@ -14,12 +14,12 @@ import io.github.bric3.fireplace.core.ui.Colors;
 import java.awt.*;
 import java.awt.geom.Rectangle2D;
 import java.util.Collections;
-import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 /**
  * Engine that paint a flamegraph.
@@ -65,7 +65,7 @@ class FlamegraphRenderEngine<T> {
     private double scaleX;
     private double scaleY;
 
-    private final List<FrameBox<T>> frames;
+    private final FrameModel<T> frameModel;
 
     /**
      * Internal padding with the component bounds.
@@ -73,21 +73,22 @@ class FlamegraphRenderEngine<T> {
     private final int internalPadding = 2;
 
     private Set<FrameBox<T>> toHighlight = Collections.emptySet();
+    private Set<FrameBox<T>> hoveredSiblingFrames = Collections.emptySet();
     private final FrameRender<T> frameRenderer;
 
     /**
      * Creates a new instance to render the specified list of frames.
      *
-     * @param frames        the frames to be displayed.
+     * @param frameModel    the frames to be displayed.
      * @param frameRenderer a configured single frame renderer.
      */
     public FlamegraphRenderEngine(
-            List<FrameBox<T>> frames,
+            FrameModel<T> frameModel,
             FrameRender<T> frameRenderer
     ) {
         this.frameRenderer = Objects.requireNonNull(frameRenderer, "frameRenderer");
-        this.frames = Objects.requireNonNull(frames, "frames");
-        this.depth = this.frames.stream().mapToInt(fb -> fb.stackDepth).max().orElse(0);
+        this.frameModel = Objects.requireNonNull(frameModel, "frameMocdel");
+        this.depth = this.frameModel.frames.stream().mapToInt(fb -> fb.stackDepth).max().orElse(0);
         visibleDepth = depth;
         updateUI();
     }
@@ -138,7 +139,7 @@ class FlamegraphRenderEngine<T> {
         // compute the canvas height for the flamegraph width
         if (canvasWidth != adjVisibleWidth) {
             var visibleDepth = 0;
-            for (var frame : frames) {
+            for (var frame : frameModel.frames) {
                 if (canvasWidth * (frame.endX - frame.startX) < frameWidthVisibilityThreshold) {
                     continue;
                 }
@@ -188,7 +189,7 @@ class FlamegraphRenderEngine<T> {
         var flameGraphWidth = minimapMode ? viewRect.getWidth() : bounds.getWidth();
         var frameRect = new Rectangle2D.Double(); // reusable rectangle
 
-
+        var frames = frameModel.frames;
         // paint root
         {
             var rootFrame = frames.get(0);
@@ -209,6 +210,7 @@ class FlamegraphRenderEngine<T> {
                                 false,
                                 false, // never make root part of highlighting
                                 hoveredFrame == rootFrame,
+                                false,
                                 selectedFrame != null,
                                 selectedFrame == rootFrame,
                                 frameRect.getX() == paintableIntersection.getX()
@@ -244,6 +246,7 @@ class FlamegraphRenderEngine<T> {
                                 !toHighlight.isEmpty(),
                                 toHighlight.contains(frame),
                                 hoveredFrame == frame,
+                                hoveredSiblingFrames.contains(frame),
                                 selectedFrame != null,
                                 (selectedFrame != null
                                  && frame.stackDepth >= selectedFrame.stackDepth
@@ -258,7 +261,7 @@ class FlamegraphRenderEngine<T> {
         if (!minimapMode) {
             paintHoveredFrameBorder(g2d, viewRect, flameGraphWidth, frameBoxHeight, frameRect);
         }
-        
+
         g2d.dispose();
     }
 
@@ -359,12 +362,12 @@ class FlamegraphRenderEngine<T> {
         double xLocation = point.x / bounds.getWidth();
         double visibilityThreshold = frameWidthVisibilityThreshold / bounds.getWidth();
 
-        return frames.stream()
-                     .filter(node -> node.stackDepth == depth
-                                     && node.startX <= xLocation
-                                     && xLocation <= node.endX
-                                     && visibilityThreshold < node.endX - node.startX)
-                     .findFirst();
+        return frameModel.frames.stream()
+                                .filter(node -> node.stackDepth == depth
+                                                && node.startX <= xLocation
+                                                && xLocation <= node.endX
+                                                && visibilityThreshold < node.endX - node.startX)
+                                .findFirst();
     }
 
     /**
@@ -408,13 +411,23 @@ class FlamegraphRenderEngine<T> {
             return;
         }
         var oldHoveredFrame = hoveredFrame;
+        var oldHoveredSiblingFrames = hoveredSiblingFrames;
         hoveredFrame = frame;
+        hoveredSiblingFrames = getSiblingFrames(frame);
         if (hoverConsumer != null) {
-            hoverConsumer.accept(getFrameRectangle(g2, bounds, frame));
+            // hoverConsumer.accept(getFrameRectangle(g2, bounds, frame));
+            hoveredSiblingFrames.forEach(hovered -> hoverConsumer.accept(getFrameRectangle(g2, bounds, hovered)));
             if (oldHoveredFrame != null) {
-                hoverConsumer.accept(getFrameRectangle(g2, bounds, oldHoveredFrame));
+                // hoverConsumer.accept(getFrameRectangle(g2, bounds, oldHoveredFrame));
+                oldHoveredSiblingFrames.forEach(hovered -> hoverConsumer.accept(getFrameRectangle(g2, bounds, hovered)));
             }
         }
+    }
+
+    private Set<FrameBox<T>> getSiblingFrames(FrameBox<T> frame) {
+        return frameModel.frames.stream()
+                                .filter(node -> frameModel.frameEquality.equal(node, frame))
+                                .collect(Collectors.toSet());
     }
 
     /**
@@ -501,9 +514,12 @@ class FlamegraphRenderEngine<T> {
      */
     public void stopHover(Graphics2D g2, Rectangle2D bounds, Consumer<Rectangle> hoverConsumer) {
         var oldHoveredFrame = hoveredFrame;
+        var oldHoveredSiblingFrame = hoveredSiblingFrames;
         hoveredFrame = null;
+        hoveredSiblingFrames = Collections.emptySet();
         if (oldHoveredFrame != null) {
-            hoverConsumer.accept(getFrameRectangle(g2, bounds, oldHoveredFrame));
+            // hoverConsumer.accept(getFrameRectangle(g2, bounds, oldHoveredFrame));
+            oldHoveredSiblingFrame.forEach(hovered -> hoverConsumer.accept(getFrameRectangle(g2, bounds, hovered)));
         }
     }
 

--- a/fireplace-swing/src/main/java/io/github/bric3/fireplace/flamegraph/FlamegraphRenderEngine.java
+++ b/fireplace-swing/src/main/java/io/github/bric3/fireplace/flamegraph/FlamegraphRenderEngine.java
@@ -75,7 +75,7 @@ class FlamegraphRenderEngine<T> {
     private Set<FrameBox<T>> toHighlight = Collections.emptySet();
     private Set<FrameBox<T>> hoveredSiblingFrames = Collections.emptySet();
     private final FrameRender<T> frameRenderer;
-    private boolean showHoveredSiblings;
+    private boolean showHoveredSiblings = true;
 
     /**
      * Creates a new instance to render the specified list of frames.

--- a/fireplace-swing/src/main/java/io/github/bric3/fireplace/flamegraph/FlamegraphView.java
+++ b/fireplace-swing/src/main/java/io/github/bric3/fireplace/flamegraph/FlamegraphView.java
@@ -265,7 +265,17 @@ public class FlamegraphView<T> {
      *
      * @param showMinimap {@code true} to show the minimap, {@code false} otherwise.
      */
+    @Deprecated(forRemoval = true)
     public void showMinimap(boolean showMinimap) {
+        setShowMinimap(showMinimap);
+    }
+
+    /**
+     * Sets a flag that controls whether the minimap is visible.
+     *
+     * @param showMinimap {@code true} to show the minimap, {@code false} otherwise.
+     */
+    public void setShowMinimap(boolean showMinimap) {
         canvas.showMinimap(showMinimap);
     }
 
@@ -276,6 +286,25 @@ public class FlamegraphView<T> {
      */
     public boolean isShowMinimap() {
         return canvas.isShowMinimap();
+    }
+
+    /**
+     * Sets a flag that controls whether the siblings of the hovered frame are highlighted.
+     *
+     * @param showHoveredSiblings {@code true} to show the siblings of the hovered frame, {@code false} otherwise.
+     */
+    public void setShowHoveredSiblings(boolean showHoveredSiblings) {
+        canvas.getFlamegraphRenderEngine()
+              .ifPresent(fre -> fre.setShowHoveredSiblings(showHoveredSiblings));
+    }
+
+    /**
+     * Whether the siblings of the hovered frame are highlighted.
+     *
+     * @return {@code true} if the siblings of the hovered frame are highlighted, {@code false} otherwise.
+     */
+    public boolean isShowHoveredSiblings() {
+        return canvas.getFlamegraphRenderEngine().map(FlamegraphRenderEngine::isShowHoveredSiblings).orElse(false);
     }
 
     /**

--- a/fireplace-swing/src/main/java/io/github/bric3/fireplace/flamegraph/FlamegraphView.java
+++ b/fireplace-swing/src/main/java/io/github/bric3/fireplace/flamegraph/FlamegraphView.java
@@ -20,7 +20,6 @@ import java.awt.event.MouseEvent;
 import java.awt.geom.Area;
 import java.awt.geom.Rectangle2D;
 import java.awt.image.BufferedImage;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -91,7 +90,7 @@ public class FlamegraphView<T> {
     /**
      * The precomputed list of frames.
      */
-    private List<FrameBox<T>> frames;
+    private FrameModel<T> framesModel;
 
     /**
      * Represents a custom actions when zooming
@@ -341,6 +340,7 @@ public class FlamegraphView<T> {
      * @param frameColorFunction  the frame to background color function.
      * @param tooltipTextFunction the frame tooltip text function.
      */
+    @Deprecated(forRemoval = true)
     public void setConfigurationAndData(
             List<FrameBox<T>> frames,
             FrameTextsProvider<T> frameTextsProvider,
@@ -348,15 +348,63 @@ public class FlamegraphView<T> {
             FrameFontProvider<T> frameFontProvider,
             Function<FrameBox<T>, String> tooltipTextFunction
     ) {
+        this.framesModel = new FrameModel<>(frames);
         var flamegraphRenderEngine = new FlamegraphRenderEngine<>(
-                frames,
+                framesModel,
                 new FrameRender<>(
                         frameTextsProvider,
                         frameColorFunction,
                         frameFontProvider
                 )
         );
-        this.frames = Objects.requireNonNull(frames);
+
+        canvas.setFlamegraphRenderEngine(Objects.requireNonNull(flamegraphRenderEngine));
+        canvas.setToolTipTextFunction(Objects.requireNonNull(tooltipTextFunction));
+
+        canvas.revalidate();
+        canvas.repaint();
+    }
+
+    /**
+     * Actually set the {@link FlamegraphView} with typed data and configure how to use it.
+     * <p>
+     * It takes a list of {@link FrameBox} objects that wraps the actual data,
+     * which is referred to as <em>node</em>.
+     * </p>
+     * <p>
+     * In particular this function defines the behavior to access the typed data:
+     * <ul>
+     *     <li>Possible string candidates to display in frames, those are
+     *     selected based on the available space</li>
+     *     <li>The root node text to display, if something specific is relevant,
+     *     like the type of events, their number, etc.</li>
+     *     <li>The frame background color, this function can be replaced by
+     *     {@link #setColorFunction(Function)}, note that the foreground color
+     *     is chosen automatically</li>
+     *     <li>The tooltip text from the current node</li>
+     * </ul>
+     *
+     * @param frameModel          The {@code FrameBox} list to display.
+     * @param frameTextsProvider  function to display label in frames.
+     * @param frameColorFunction  the frame to background color function.
+     * @param tooltipTextFunction the frame tooltip text function.
+     */
+    public void setConfigurationAndData(
+            FrameModel<T> frameModel,
+            FrameTextsProvider<T> frameTextsProvider,
+            FrameColorProvider<T> frameColorFunction,
+            FrameFontProvider<T> frameFontProvider,
+            Function<FrameBox<T>, String> tooltipTextFunction
+    ) {
+        framesModel = Objects.requireNonNull(frameModel);
+        var flamegraphRenderEngine = new FlamegraphRenderEngine<>(
+                framesModel,
+                new FrameRender<>(
+                        frameTextsProvider,
+                        frameColorFunction,
+                        frameFontProvider
+                )
+        );
 
         canvas.setFlamegraphRenderEngine(Objects.requireNonNull(flamegraphRenderEngine));
         canvas.setToolTipTextFunction(Objects.requireNonNull(tooltipTextFunction));
@@ -369,14 +417,18 @@ public class FlamegraphView<T> {
      * Clear all data.
      */
     public void clear() {
-        frames = Collections.emptyList();
+        framesModel = FrameModel.empty();
         canvas.setFlamegraphRenderEngine(null);
         canvas.invalidate();
         canvas.repaint();
     }
 
+    public FrameModel<T> getFrameModel() {
+        return framesModel;
+    }
+
     public List<FrameBox<T>> getFrames() {
-        return frames;
+        return framesModel.frames;
     }
 
     /**
@@ -540,9 +592,7 @@ public class FlamegraphView<T> {
             var viewPort = scrollPane.getViewport();
 
             // this seems to enable key navigation
-            if ((e.getComponent() instanceof JScrollPane)) {
-                e.getComponent().requestFocus();
-            }
+            scrollPane.requestFocus();
 
             var latestMouseLocation = MouseInfo.getPointerInfo().getLocation();
             SwingUtilities.convertPointFromScreen(latestMouseLocation, canvas);

--- a/fireplace-swing/src/main/java/io/github/bric3/fireplace/flamegraph/FrameModel.java
+++ b/fireplace-swing/src/main/java/io/github/bric3/fireplace/flamegraph/FrameModel.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2021 Datadog, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.bric3.fireplace.flamegraph;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Represent the model of the flamegraph.
+ *
+ * @param <T> The type of the actual node object.
+ * @see FrameBox
+ */
+public class FrameModel<T> {
+    public static final FrameModel<?> EMPTY = new FrameModel<>(Collections.emptyList());
+    List<FrameBox<T>> frames;
+    FrameEquality<T> frameEquality;
+
+    /**
+     * Creates model of the flamegraph frames.
+     *
+     * <p>It takes a list of {@link FrameBox} objects that wraps the actual data,
+     * which is referred to as <em>node</em>.
+     * </p>.
+     *
+     * <p>
+     * The equality applies equals on the actual node object {@link T}.
+     * </p>
+     *
+     * @param frames The list of {@code FrameBox} objects.
+     */
+    public FrameModel(List<FrameBox<T>> frames) {
+        this((a, b) -> Objects.equals(a.actualNode, b.actualNode), frames);
+    }
+
+    /**
+     * Creates model of the flamegraph frames.
+     *
+     * <p>It takes a list of {@link FrameBox} objects that wraps the actual data,
+     * which is referred to as <em>node</em>.
+     * </p>.
+     *
+     * @param frameEquality Custom equality code for the actual node object {@code T}.
+     * @param frames        The list of {@code FrameBox} objects.
+     */
+    public FrameModel(FrameEquality<T> frameEquality, List<FrameBox<T>> frames) {
+        this.frames = Objects.requireNonNull(frames, "frames");
+        this.frameEquality = Objects.requireNonNull(frameEquality, "frameEquality");
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> FrameModel<T> empty() {
+        return (FrameModel<T>) EMPTY;
+    }
+
+    /**
+     * Returns whether two frames are considered equal.
+     *
+     * @param <T> The type of the actual node object.
+     */
+    public interface FrameEquality<T> {
+        boolean equal(FrameBox<T> a, FrameBox<T> b);
+    }
+}

--- a/fireplace-swing/src/main/java/io/github/bric3/fireplace/flamegraph/FrameRenderingFlags.java
+++ b/fireplace-swing/src/main/java/io/github/bric3/fireplace/flamegraph/FrameRenderingFlags.java
@@ -51,20 +51,25 @@ public abstract class FrameRenderingFlags {
     public static int HOVERED = 1 << 3;
 
     /**
+     * The renderer is currently rendering the sibling of a hovered frame
+     */
+    public static int HOVERED_SIBLING = 1 << 4;
+
+    /**
      * The renderer is currently focusing some frames (a "sub-flame")
      */
-    public static int FOCUSING = 1 << 4;
+    public static int FOCUSING = 1 << 5;
 
     /**
      * The renderer is currently rendering a focused frame.
      */
-    public static int FOCUSED_FRAME = 1 << 5;
+    public static int FOCUSED_FRAME = 1 << 6;
 
     /**
      * The renderer is currently rendering a partial frame, e.g. it is larger
      * that the painting area.
      */
-    public static int PARTIAL_FRAME = 1 << 6;
+    public static int PARTIAL_FRAME = 1 << 7;
 
 
     public static int toFlags(
@@ -72,6 +77,7 @@ public abstract class FrameRenderingFlags {
             boolean highlightingOn,
             boolean highlighted,
             boolean hovered,
+            boolean hoveredSibling,
             boolean focusing,
             boolean focusedFrame,
             boolean partialFrame
@@ -80,6 +86,7 @@ public abstract class FrameRenderingFlags {
                | (highlightingOn ? HIGHLIGHTING : 0)
                | (highlighted ? HIGHLIGHTED_FRAME : 0)
                | (hovered ? HOVERED : 0)
+               | (hoveredSibling ? HOVERED_SIBLING : 0)
                | (focusing ? FOCUSING : 0)
                | (focusedFrame ? FOCUSED_FRAME : 0)
                | (partialFrame ? PARTIAL_FRAME : 0);
@@ -91,6 +98,7 @@ public abstract class FrameRenderingFlags {
         if ((flags & HIGHLIGHTING) != 0) sb.add("highlighting");
         if ((flags & HIGHLIGHTED_FRAME) != 0) sb.add("highlighted");
         if ((flags & HOVERED) != 0) sb.add("hovered");
+        if ((flags & HOVERED_SIBLING) != 0) sb.add("hovered sibling");
         if ((flags & FOCUSING) != 0) sb.add("focusing");
         if ((flags & FOCUSED_FRAME) != 0) sb.add("focused");
         if ((flags & PARTIAL_FRAME) != 0) sb.add("partial");
@@ -111,6 +119,10 @@ public abstract class FrameRenderingFlags {
 
     public static boolean isHovered(int flags) {
         return (flags & HOVERED) != 0;
+    }
+
+    public static boolean isHoveredSibling(int flags) {
+        return (flags & HOVERED_SIBLING) != 0;
     }
 
     public static boolean isFocusing(int flags) {


### PR DESCRIPTION
<img width="1112" alt="image" src="https://user-images.githubusercontent.com/803621/178774748-04692732-a887-4573-b887-3a7176244c8c.png">


https://user-images.githubusercontent.com/803621/179066510-9cf903ee-33bc-4037-a672-a2f972724c6d.mov



_Hovered frame coloring may be revisited_.
The code allows the distinction of the frame under the mouse pointer, and the sibling frames.

Fixes #80