### PR TITLE
fix: no scrollbar on first display

### DIFF
--- a/fireplace-swing/src/main/java/io/github/bric3/fireplace/flamegraph/FlamegraphRenderEngine.java
+++ b/fireplace-swing/src/main/java/io/github/bric3/fireplace/flamegraph/FlamegraphRenderEngine.java
@@ -138,6 +138,7 @@ class FlamegraphRenderEngine<T> {
         this.frameModel = Objects.requireNonNull(frameModel, "frameModel");
         this.depth = frameModel.frames.stream().mapToInt(fb -> fb.stackDepth).max().orElse(0) + 1;
         visibleDepth = depth;
+        visibleDepthCache.clear();
         return this;
     }
 
@@ -150,6 +151,7 @@ class FlamegraphRenderEngine<T> {
         this.frameModel = FrameModel.empty();
         this.depth = 1;
         visibleDepth = 1;
+        visibleDepthCache.clear();
         return this;
     }
 

--- a/fireplace-swing/src/main/java/io/github/bric3/fireplace/flamegraph/FlamegraphView.java
+++ b/fireplace-swing/src/main/java/io/github/bric3/fireplace/flamegraph/FlamegraphView.java
@@ -506,8 +506,11 @@ public class FlamegraphView<T> {
         framesModel = Objects.requireNonNull(frameModel);
         canvas.getFlamegraphRenderEngine().ifPresent(fre -> fre.init(frameModel));
 
-        canvas.revalidate();
-        canvas.repaint();
+        // force invalidation of the canvas so that the scrollpane will fetch the new preferredSize
+        // otherwise old cached preferredSize will be used.
+        canvas.invalidate();
+        component.revalidate();
+        component.repaint();
     }
 
     /**


### PR DESCRIPTION
This was caused by the fact that the component
required explicit invalidation when changing the model, otherwise the preferredSize is not re-computed.

There was also a caching issue preventing to recompute the new height.